### PR TITLE
WL-327 Keep URL through login with internal users

### DIFF
--- a/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
+++ b/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
@@ -215,7 +215,11 @@ public class SkinnableLogin extends HttpServlet implements Login {
 
 				//SAK-21498 choice page for selecting auth sources
 				showAuthChoice = serverConfigurationService.getBoolean("login.auth.choice", false);
-				URL helperUrl = new URL((String) session.getAttribute(Tool.HELPER_DONE_URL));
+				URL helperUrl = null;
+				// /portal/relogin doesn't explicitly set a HELPER_DONE_URL so we can't be sure it's there.
+				if (session.getAttribute(Tool.HELPER_DONE_URL) != null) {
+					helperUrl = new URL((String) session.getAttribute(Tool.HELPER_DONE_URL));
+				}
 				String helperPath = helperUrl == null ? null : helperUrl.getPath();
 
 				if (showAuthChoice && !(StringUtils.isEmpty(helperPath) || helperPath.equals("/portal") || 

--- a/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
+++ b/login-tool/tool/src/java/org/sakaiproject/login/tool/SkinnableLogin.java
@@ -220,7 +220,7 @@ public class SkinnableLogin extends HttpServlet implements Login {
 
 				if (showAuthChoice && !(StringUtils.isEmpty(helperPath) || helperPath.equals("/portal") || 
 						helperPath.equals("/portal/") || helperPath.equals("/portal/pda") || helperPath.equals("/portal/pda/"))) {
-					String xloginUrl = serverConfigurationService.getPortalUrl() + "/xlogin";
+					String xloginUrl = Web.serverUrl(req) + getServletConfig().getInitParameter("xlogin");
 
 					// Present the choice template
 					LoginRenderContext rcontext = startChoiceContext("", req, res);

--- a/login-tool/tool/src/webapp/WEB-INF/web.xml
+++ b/login-tool/tool/src/webapp/WEB-INF/web.xml
@@ -80,6 +80,10 @@
             <param-value>/sakai-login-tool/container</param-value>
         </init-param>
         <init-param>
+            <param-name>xlogin</param-name>
+            <param-value>/sakai-login-tool/xlogin</param-value>
+        </init-param>
+        <init-param>
         	<param-name>container-logout</param-name>
         	<param-value>/sakai-login-tool/container/logout</param-value>
         </init-param>


### PR DESCRIPTION
Now once you've passed the login route page you end up using /sakai-login-tool/\* so that the portal doesn't reset the helper done URL.
